### PR TITLE
Multi-display support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You describe a layout once (in JSON), then run the script whenever you need that
 * Falls back to a configurable "stash" workspace so your primary workspace starts clean.
 * One-line listing of all available layouts.
 * Optional **fractional sizing** for windows and groups via a simple `size` field (e.g. `"size": "2/3"`).
+* Supports **multi-display setups** with the `display` field to correctly calculate window sizes, in a per-layout basis.
 
 ---
 
@@ -64,6 +65,8 @@ Field reference:
     * `{ "bundleId": "…", "size": "n/d" }` – an application window, optionally sized as a fraction.
     * `{ "orientation": "horizontal" | "vertical", "size": "n/d", "windows": [ … ] }` – a nested group, optionally sized as a fraction.
   * **size** – *(optional)* fractional width/height (`"numerator/denominator"`). In a horizontal context (`orientation: "horizontal"`) the fraction controls width; in a vertical context it controls height.
+  * **display** – *(optional)* display *name* or *ID* (as shown by `system_profiler SPDisplaysDataType`), or a valid alias (`main`, `secondary`, `external`, `internal`).
+    * In multi-display setups, you can specify the target display for a layout in order to correctly calculate window sizes (if specified with `size`). By default, the layout will be applied to the primary display.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -205,13 +205,13 @@ function getDisplayByAlias(
 ): DisplayInfo | undefined {
   switch (alias) {
     case DisplayAlias.Main:
-      return displays.find((d) => d.isMain);
+      return getMainDisplay(displays);
     case DisplayAlias.Secondary:
       if (displays.length < 2) {
         console.log(
           "Alias 'secondary' is used, but only one display found. Defaulting to the main display."
         );
-        return displays.find((d) => d.isMain);
+        return getMainDisplay(displays);
       }
       if (displays.length > 2) {
         throw new Error(
@@ -225,7 +225,7 @@ function getDisplayByAlias(
         console.log(
           "Alias 'external' is used, but no external displays found. Defaulting to the main display."
         );
-        return displays.find((d) => d.isMain);
+        return getMainDisplay(displays);
       }
       if (externalDisplays.length > 1) {
         throw new Error(
@@ -250,6 +250,10 @@ function getDisplayById(
   displays: DisplayInfo[]
 ): DisplayInfo | undefined {
   return displays.find((d) => d.id === id);
+}
+
+function getMainDisplay(displays: DisplayInfo[]): DisplayInfo | undefined {
+  return displays.find((d) => d.isMain);
 }
 
 function selectDisplay(layout: any, displays: DisplayInfo[]): DisplayInfo {

--- a/index.ts
+++ b/index.ts
@@ -46,6 +46,7 @@ type Layout = {
   layout: WorkspaceLayout;
   orientation: Orientation;
   windows: LayoutItem[];
+  display?: string | number;
 };
 
 type LayoutConfig = {
@@ -134,7 +135,9 @@ const displays = getDisplays();
 if (!displays) {
   throw new Error(`No displays found. Please, debug with ${SPDisplayCommand}`);
 }
-const selectedDisplay = selectDisplay(layout, displays);
+const selectedDisplay = layout.display
+  ? selectDisplay(layout, displays)
+  : getDisplayByAlias(DisplayAlias.Main, displays);
 if (!selectedDisplay) {
   throw new Error(
     `A display could not be selected for layout "${layoutName}". Please check your configuration.`

--- a/index.ts
+++ b/index.ts
@@ -2,72 +2,99 @@
 
 import { $ } from "bun";
 import { parseArgs } from "node:util";
+import { execSync } from "node:child_process";
 
 // Types
 type WorkspaceLayout =
-	| "h_tiles"
-	| "v_tiles"
-	| "h_accordion"
-	| "v_accordion"
-	| "tiles"
-	| "accordion"
-	| "horizontal"
-	| "vertical"
-	| "tiling"
-	| "floating";
+  | "h_tiles"
+  | "v_tiles"
+  | "h_accordion"
+  | "v_accordion"
+  | "tiles"
+  | "accordion"
+  | "horizontal"
+  | "vertical"
+  | "tiling"
+  | "floating";
 type Orientation = "horizontal" | "vertical";
 type Size = `${number}/${number}`;
 interface LayoutWindow {
-	bundleId: string;
+  bundleId: string;
 }
 
 interface LayoutWindowWithSize extends LayoutWindow {
-	size: Size;
+  size: Size;
 }
 
 interface LayoutGroup {
-	orientation: Orientation;
-	windows: LayoutWindow[];
+  orientation: Orientation;
+  windows: LayoutWindow[];
 }
 
 interface LayoutGroupWithSize extends LayoutGroup {
-	size: Size;
+  size: Size;
 }
 
 type LayoutItem =
-	| LayoutWindow
-	| LayoutGroup
-	| LayoutWindowWithSize
-	| LayoutGroupWithSize;
+  | LayoutWindow
+  | LayoutGroup
+  | LayoutWindowWithSize
+  | LayoutGroupWithSize;
 
 type Layout = {
-	workspace: string;
-	layout: WorkspaceLayout;
-	orientation: Orientation;
-	windows: LayoutItem[];
+  workspace: string;
+  layout: WorkspaceLayout;
+  orientation: Orientation;
+  windows: LayoutItem[];
 };
 
 type LayoutConfig = {
-	stashWorkspace: string;
-	layouts: Record<string, Layout>;
+  stashWorkspace: string;
+  layouts: Record<string, Layout>;
 };
+
+type DisplayInfo = {
+  id?: number;
+  name: string;
+  width: number;
+  height: number;
+  isMain: boolean;
+  isInternal?: boolean;
+};
+
+// macOS system_profiler SPDisplaysDataType reporter's values
+enum SPDisplaysValues {
+  Yes = "spdisplays_yes",
+  No = "spdisplays_no",
+  Supported = "spdisplays_supported",
+  Internal = "spdisplays_internal",
+}
+
+const SPDisplayCommand = "system_profiler SPDisplaysDataType -json";
+
+enum DisplayAlias {
+  Main = "main",
+  Secondary = "secondary",
+  External = "external",
+  Internal = "internal",
+}
 
 // Setup
 
 const args = parseArgs({
-	args: process.argv.slice(2),
-	options: {
-		layout: { type: "string", short: "l" },
-		configFile: {
-			type: "string",
-			short: "c",
-			default: "~/.config/aerospace/layouts.json",
-		},
-		listLayouts: { type: "boolean", short: "L" },
-		help: { type: "boolean", short: "h" },
-	},
-	strict: true,
-	allowPositionals: true,
+  args: process.argv.slice(2),
+  options: {
+    layout: { type: "string", short: "l" },
+    configFile: {
+      type: "string",
+      short: "c",
+      default: "~/.config/aerospace/layouts.json",
+    },
+    listLayouts: { type: "boolean", short: "L" },
+    help: { type: "boolean", short: "h" },
+  },
+  strict: true,
+  allowPositionals: true,
 });
 
 const layoutName = args.values.layout || args.positionals[0];
@@ -75,252 +102,367 @@ const configFilePath = await $`echo ${args.values.configFile}`.text();
 const layoutConfig: LayoutConfig = await Bun.file(configFilePath.trim()).json();
 
 if (args.values.listLayouts) {
-	console.log(Object.keys(layoutConfig.layouts).join("\n"));
-	process.exit(0);
+  console.log(Object.keys(layoutConfig.layouts).join("\n"));
+  process.exit(0);
 }
 
 function printHelp() {
-	console.log(
-		`\nAerospace Layout Manager\n\nUsage:\n  aerospace-layout-manager [options] <layout-name>\n\nOptions:\n  -l, --layout <layout-name>   Specify the layout name (can also be provided as the first positional argument)\n  -c, --configFile <path>      Path to the layout configuration file (default: ~/.config/aerospace/layouts.json)\n  -L, --listLayouts            List available layout names from the configuration file\n  -h, --help                   Show this help message and exit\n\nExamples:\n  # Apply the 'work' layout defined in the config\n  aerospace-layout-manager work\n\n  # Same as above using the explicit flag\n  aerospace-layout-manager --layout work\n\n  # List all available layouts\n  aerospace-layout-manager --listLayouts\n`,
-	);
+  console.log(
+    `\nAerospace Layout Manager\n\nUsage:\n  aerospace-layout-manager [options] <layout-name>\n\nOptions:\n  -l, --layout <layout-name>   Specify the layout name (can also be provided as the first positional argument)\n  -c, --configFile <path>      Path to the layout configuration file (default: ~/.config/aerospace/layouts.json)\n  -L, --listLayouts            List available layout names from the configuration file\n  -h, --help                   Show this help message and exit\n\nExamples:\n  # Apply the 'work' layout defined in the config\n  aerospace-layout-manager work\n\n  # Same as above using the explicit flag\n  aerospace-layout-manager --layout work\n\n  # List all available layouts\n  aerospace-layout-manager --listLayouts\n`
+  );
 }
 
 // Show help and exit if requested explicitly
 if (args.values.help || layoutName === "help") {
-	printHelp();
-	process.exit(0);
+  printHelp();
+  process.exit(0);
 }
 
 if (!layoutName) {
-	printHelp();
-	process.exit(0);
+  printHelp();
+  process.exit(0);
 }
 
 const layout = layoutConfig.layouts[layoutName];
 const stashWorkspace = layoutConfig.stashWorkspace ?? "S";
 
 if (!layout) {
-	throw new Error("Layout not found");
+  throw new Error("Layout not found");
+}
+
+const displays = getDisplays();
+if (!displays) {
+  throw new Error(`No displays found. Please, debug with ${SPDisplayCommand}`);
+}
+console.log(displays);
+const selectedDisplay = selectDisplay(layout, displays);
+if (!selectedDisplay) {
+  throw new Error(
+    `A display could not be selected for layout "${layoutName}". Please check your configuration.`
+  );
 }
 
 // Helpers
 
 async function flattenWorkspace(workspace: string) {
-	await $`aerospace flatten-workspace-tree --workspace ${workspace}`.nothrow();
+  await $`aerospace flatten-workspace-tree --workspace ${workspace}`.nothrow();
 }
 
 async function switchToWorkspace(workspace: string) {
-	await $`aerospace workspace ${workspace}`.nothrow();
+  await $`aerospace workspace ${workspace}`.nothrow();
 }
 
 async function moveWindow(windowId: string, workspace: string) {
-	await $`aerospace move-node-to-workspace --window-id "${windowId}" "${workspace}" --focus-follows-window`;
+  await $`aerospace move-node-to-workspace --window-id "${windowId}" "${workspace}" --focus-follows-window`;
 }
 
 async function getWindowsInWorkspace(workspace: string): Promise<
-	{
-		"app-name": string;
-		"window-id": string;
-		"window-title": string;
-		"app-bundle-id": string;
-	}[]
+  {
+    "app-name": string;
+    "window-id": string;
+    "window-title": string;
+    "app-bundle-id": string;
+  }[]
 > {
-	return await $`aerospace list-windows --workspace ${workspace} --json --format "%{window-id} %{app-name} %{window-title} %{app-bundle-id}"`.json();
+  return await $`aerospace list-windows --workspace ${workspace} --json --format "%{window-id} %{app-name} %{window-title} %{app-bundle-id}"`.json();
 }
 
 async function joinItemWithPreviousWindow(windowId: string) {
-	await $`aerospace join-with --window-id ${windowId} left`.nothrow();
+  await $`aerospace join-with --window-id ${windowId} left`.nothrow();
 }
 
 async function focusWindow(windowId: string) {
-	await $`aerospace focus --window-id ${windowId}`.nothrow();
+  await $`aerospace focus --window-id ${windowId}`.nothrow();
+}
+
+function getDisplays(): DisplayInfo[] {
+  const json = execSync(SPDisplayCommand, { encoding: "utf8" });
+  const data = JSON.parse(json);
+  return data.SPDisplaysDataType.flatMap((gpu: any) =>
+    gpu.spdisplays_ndrvs.map((d: any) => ({
+      name: d._name,
+      id: parseInt(d._spdisplays_displayID) || undefined,
+      width: parseInt(
+        (d._spdisplays_resolution || d.spdisplays_resolution || "").split(
+          " x "
+        )[0],
+        10
+      ),
+      height: parseInt(
+        (d._spdisplays_resolution || d.spdisplays_resolution || "").split(
+          " x "
+        )[1],
+        10
+      ),
+      isMain: d.spdisplays_main === SPDisplaysValues.Yes,
+      isInternal: d.spdisplays_connection_type === SPDisplaysValues.Internal,
+    }))
+  );
+}
+
+function getDisplayByAlias(
+  alias: DisplayAlias,
+  displays: DisplayInfo[]
+): DisplayInfo | undefined {
+  console.log("Getting display by alias:", alias, alias in DisplayAlias);
+  switch (alias) {
+    case DisplayAlias.Main:
+      return displays.find((d) => d.isMain);
+    case DisplayAlias.Secondary:
+      if (displays.length < 2) {
+        console.log(
+          "Alias 'secondary' is used, but only one display found. Defaulting to the main display."
+        );
+        return displays.find((d) => d.isMain);
+      }
+      if (displays.length > 2) {
+        throw new Error(
+          "Alias 'secondary' is used, but multiple secondary displays are found. Please specify an exact display name or use a different alias."
+        );
+      }
+      return displays.find((d) => !d.isMain);
+    case DisplayAlias.External:
+      const externalDisplays = displays.filter((d) => !d.isInternal);
+      if (externalDisplays.length === 0) {
+        console.log(
+          "Alias 'external' is used, but no external displays found. Defaulting to the main display."
+        );
+        return displays.find((d) => d.isMain);
+      }
+      if (externalDisplays.length > 1) {
+        throw new Error(
+          "Multiple external displays found. Please specify an exact display name or use a different alias."
+        );
+      }
+      return externalDisplays[0];
+    case DisplayAlias.Internal:
+      return displays.find((d) => d.isInternal);
+  }
+}
+
+function getDisplayByName(
+  regExp: string,
+  displays: DisplayInfo[]
+): DisplayInfo | undefined {
+  return displays.find((d) => new RegExp(regExp, "i").test(d.name));
+}
+
+function getDisplayById(
+  id: number,
+  displays: DisplayInfo[]
+): DisplayInfo | undefined {
+  return displays.find((d) => d.id === id);
+}
+
+function selectDisplay(layout: any, displays: DisplayInfo[]): DisplayInfo {
+  let selectedDisplay: DisplayInfo | undefined;
+  if (layout.display) {
+    if (typeof layout.display === "string" && isNaN(Number(layout.display))) {
+      const isAlias = Object.values(DisplayAlias).includes(
+        layout.display as DisplayAlias
+      );
+      if (isAlias) {
+        selectedDisplay = getDisplayByAlias(layout.display, displays);
+      } else {
+        selectedDisplay = getDisplayByName(layout.display, displays);
+      }
+    } else if (
+      typeof layout.display === "number" ||
+      !isNaN(Number(layout.display))
+    ) {
+      const displayId = Number(layout.display);
+      selectedDisplay = getDisplayById(displayId, displays);
+    }
+  }
+
+  if (!selectedDisplay) {
+    throw new Error(
+      `Display not found: ${layout.display}. Please specify a valid display name, alias, or ID. Defaulting to the main display.`
+    );
+  }
+
+  console.log(
+    `Using display: ${selectedDisplay.name} (${selectedDisplay.width}x${
+      selectedDisplay.height
+    }) (${selectedDisplay.isMain ? "main" : "secondary"}, ${
+      selectedDisplay.isInternal ? "internal" : "external"
+    })`
+  );
+
+  return selectedDisplay;
 }
 
 /**
- * Return the width of the current (primary) monitor in pixels.
+ * Return the width of the current (primary) display in pixels.
  * Uses AppleScript because Aerospace does not expose this information.
  */
-async function getMonitorWidth(): Promise<number | null> {
-	try {
-		/*
-      AppleScript:  bounds of window of desktop -> {x1, y1, x2, y2}
-      Width  = x2 - x1
-    */
-		const output =
-			await $`osascript -e 'tell application "Finder" to get bounds of window of desktop'`.text();
-		const parts = output
-			.split(/,\s*/) // split into ["0", "0", "1440", "900"]
-			.map((v) => Number.parseInt(v.trim(), 10))
-			.filter((n) => !Number.isNaN(n));
-
-		if (parts.length === 4) {
-			const [x1, , x2] = parts;
-			return x2 - x1;
-		}
-		return null;
-	} catch (error) {
-		console.error("Unable to determine monitor width", error);
-		return null;
-	}
+async function getDisplayWidth(): Promise<number | null> {
+  return selectedDisplay?.width ?? null;
 }
 
-async function getMonitorHeight(): Promise<number | null> {
-    try {
-        const output = await $`osascript -e 'tell application "Finder" to get bounds of window of desktop'`.text();
-        const parts = output.split(/,\s*/).map(v => Number.parseInt(v.trim(), 10)).filter(n => !Number.isNaN(n));
-        if(parts.length === 4) {
-            const [, y1, , y2] = parts;
-            return y2 - y1;
-        }
-        return null;
-    } catch (error) {
-        console.error("Unable to determine monitor height", error);
-        return null;
-    }
+async function getDisplayHeight(): Promise<number | null> {
+  return selectedDisplay?.height ?? null;
 }
 
 // Functions
 
 // remove all windows from workspace
 async function clearWorkspace(workspace: string) {
-	const windows = await getWindowsInWorkspace(workspace);
+  const windows = await getWindowsInWorkspace(workspace);
 
-	for (const window of windows) {
-		if (window["window-id"]) {
-			await moveWindow(window["window-id"], stashWorkspace);
-		}
-	}
+  for (const window of windows) {
+    if (window["window-id"]) {
+      await moveWindow(window["window-id"], stashWorkspace);
+    }
+  }
 }
 
 async function getWindowId(bundleId: string) {
-	const bundleJson =
-		await $`aerospace list-windows --monitor all --app-bundle-id "${bundleId}" --json`.json();
-	const windowId = bundleJson?.length > 0 ? bundleJson[0]["window-id"] : null;
-	if (!windowId) {
-		console.log("No windowId found for", bundleId);
-	}
-	return windowId;
+  const bundleJson =
+    await $`aerospace list-windows --monitor all --app-bundle-id "${bundleId}" --json`.json();
+  const windowId = bundleJson?.length > 0 ? bundleJson[0]["window-id"] : null;
+  if (!windowId) {
+    console.log("No windowId found for", bundleId);
+  }
+  return windowId;
 }
 
 async function launchIfNotRunning(bundleId: string) {
-	const isRunning =
-		(await $`osascript -e "application id \"${bundleId}\" is running" | grep -q true`.text()) ===
-		"true";
-	if (!isRunning) {
-		await $`open -b "${bundleId}"`;
-	}
+  const isRunning =
+    (await $`osascript -e "application id \"${bundleId}\" is running" | grep -q true`.text()) ===
+    "true";
+  if (!isRunning) {
+    await $`open -b "${bundleId}"`;
+  }
 }
 
 async function ensureWindow(bundleId: string) {
-	await launchIfNotRunning(bundleId);
-	for await (const i of Array(30)) {
-		const windowId = await getWindowId(bundleId);
-		if (windowId) {
-			return windowId;
-		}
-		await new Promise((resolve) => setTimeout(resolve, 100));
-	}
-	return null;
+  await launchIfNotRunning(bundleId);
+  for await (const i of Array(30)) {
+    const windowId = await getWindowId(bundleId);
+    if (windowId) {
+      return windowId;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return null;
 }
 
 async function setWorkspaceLayout(workspace: string, layout: WorkspaceLayout) {
-	const workspaceWindows = await getWindowsInWorkspace(workspace);
-	if (workspaceWindows.length > 0) {
-		const windowId = workspaceWindows?.[0]?.["window-id"];
-		await $`aerospace layout ${layout} --window-id ${windowId}`.nothrow();
-	}
+  const workspaceWindows = await getWindowsInWorkspace(workspace);
+  if (workspaceWindows.length > 0) {
+    const windowId = workspaceWindows?.[0]?.["window-id"];
+    await $`aerospace layout ${layout} --window-id ${windowId}`.nothrow();
+  }
 }
 
 async function traverseTreeMove(tree: LayoutItem[], depth = 0) {
-	for await (const [i, item] of tree.entries()) {
-		if ("bundleId" in item) {
-			const windowId = await ensureWindow(item.bundleId);
+  for await (const [i, item] of tree.entries()) {
+    if ("bundleId" in item) {
+      const windowId = await ensureWindow(item.bundleId);
 
-			if (windowId) {
-				await moveWindow(windowId, layout.workspace);
-			}
-		} else if ("windows" in item) {
-			await traverseTreeMove(item.windows, depth + 1);
-		}
-	}
+      if (windowId) {
+        await moveWindow(windowId, layout.workspace);
+      }
+    } else if ("windows" in item) {
+      await traverseTreeMove(item.windows, depth + 1);
+    }
+  }
 }
 
 async function traverseTreeReposition(tree: LayoutItem[], depth = 0) {
-	for await (const [i, item] of tree.entries()) {
-		if (depth === 0 && i === 0) {
-			// set workspace layout after moving first window
-			await flattenWorkspace(layout.workspace);
-			await setWorkspaceLayout(layout.workspace, layout.layout);
-		}
-		if ("bundleId" in item) {
-			if (depth > 0 && i > 0) {
-				// subsequent windows in a group should be joined with the previous window
-				const windowId = await getWindowId(item.bundleId);
-				if (windowId) {
-					await focusWindow(windowId);
-					await joinItemWithPreviousWindow(windowId);
-				}
-			}
-		} else if ("windows" in item) {
-			console.log("section:", item.orientation, "depth:", depth);
-			await traverseTreeReposition(item.windows, depth + 1);
-		}
-	}
+  for await (const [i, item] of tree.entries()) {
+    if (depth === 0 && i === 0) {
+      // set workspace layout after moving first window
+      await flattenWorkspace(layout.workspace);
+      await setWorkspaceLayout(layout.workspace, layout.layout);
+    }
+    if ("bundleId" in item) {
+      if (depth > 0 && i > 0) {
+        // subsequent windows in a group should be joined with the previous window
+        const windowId = await getWindowId(item.bundleId);
+        if (windowId) {
+          await focusWindow(windowId);
+          await joinItemWithPreviousWindow(windowId);
+        }
+      }
+    } else if ("windows" in item) {
+      console.log("section:", item.orientation, "depth:", depth);
+      await traverseTreeReposition(item.windows, depth + 1);
+    }
+  }
 }
 
-async function resizeWindow(windowId: string, size: Size, dimension: "width" | "height") {
-    console.log("Resizing window", windowId, "to", size);
-	const screenDimension = dimension === "width" ? await getMonitorWidth() : await getMonitorHeight();
-	const [numerator, denominator] = size.split("/").map(Number);
-    console.log("Screen dimension:", screenDimension);
-    console.log("Numerator:", numerator);
-    console.log("Denominator:", denominator);
-	if (!screenDimension || !numerator || !denominator) {
-		console.error("Unable to determine monitor width");
-		return;
-	}
-	const newWidth = screenDimension * (numerator / denominator);
-    console.log("New width:", newWidth);
-    console.log("Command:", `aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`);
-	await $`aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`.nothrow();
+async function resizeWindow(
+  windowId: string,
+  size: Size,
+  dimension: "width" | "height"
+) {
+  console.log("Resizing window", windowId, "to", size);
+  const screenDimension =
+    dimension === "width" ? await getDisplayWidth() : await getDisplayHeight();
+  const [numerator, denominator] = size.split("/").map(Number);
+  console.log("Screen dimension:", screenDimension);
+  console.log("Numerator:", numerator);
+  console.log("Denominator:", denominator);
+  if (!screenDimension || !numerator || !denominator) {
+    console.error("Unable to determine display width");
+    return;
+  }
+  const newWidth = Math.floor(screenDimension * (numerator / denominator));
+  console.log("New width:", newWidth);
+  console.log(
+    "Command:",
+    `aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`
+  );
+  await $`aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`.nothrow();
 }
 
 function getDimension(item: LayoutItem) {
-    console.log("Item:", item);
-    if("orientation" in item) {
-        return item.orientation === "horizontal" ? "width" : "height";
-    }
-    return layout.orientation === "horizontal" ? "width" : "height";
+  console.log("Item:", item);
+  if ("orientation" in item) {
+    return item.orientation === "horizontal" ? "width" : "height";
+  }
+  return layout.orientation === "horizontal" ? "width" : "height";
 }
 
 async function traverseTreeResize(
-	tree: LayoutItem[],
-	depth = 0,
-    parent: LayoutItem | null = null
+  tree: LayoutItem[],
+  depth = 0,
+  parent: LayoutItem | null = null
 ) {
-	for await (const [i, item] of tree.entries()) {
-		if ("size" in item && "bundleId" in item) {
-            const windowId = await getWindowId(item.bundleId);
-       
-            const dimension = getDimension(parent ?? item);
-			await resizeWindow(windowId, item.size, dimension);
-		} else if ("windows" in item) {
-			const firstChildWindow = item.windows[0];
-            console.log("Parent:", parent, "Item:", item);
-            console.log("First child window:", firstChildWindow);
-			if (
-				"size" in item &&
-				firstChildWindow &&
-				"bundleId" in firstChildWindow
-			) {
-                console.log("Resizing first child window:", firstChildWindow.bundleId, "to", item.size);
-                const windowId = await getWindowId(firstChildWindow.bundleId);
-                const dimension = parent ? getDimension(parent) : layout.orientation === "horizontal" ? "width" : "height";
-				await resizeWindow(windowId, item.size, dimension);
-			}
-			await traverseTreeResize(item.windows, depth + 1, item);
-		}
-	}
+  for await (const [i, item] of tree.entries()) {
+    if ("size" in item && "bundleId" in item) {
+      const windowId = await getWindowId(item.bundleId);
+
+      const dimension = getDimension(parent ?? item);
+      await resizeWindow(windowId, item.size, dimension);
+    } else if ("windows" in item) {
+      const firstChildWindow = item.windows[0];
+      console.log("Parent:", parent, "Item:", item);
+      console.log("First child window:", firstChildWindow);
+      if (
+        "size" in item &&
+        firstChildWindow &&
+        "bundleId" in firstChildWindow
+      ) {
+        console.log(
+          "Resizing first child window:",
+          firstChildWindow.bundleId,
+          "to",
+          item.size
+        );
+        const windowId = await getWindowId(firstChildWindow.bundleId);
+        const dimension = parent
+          ? getDimension(parent)
+          : layout.orientation === "horizontal"
+          ? "width"
+          : "height";
+        await resizeWindow(windowId, item.size, dimension);
+      }
+      await traverseTreeResize(item.windows, depth + 1, item);
+    }
+  }
 }
 
 // Main

--- a/index.ts
+++ b/index.ts
@@ -300,7 +300,10 @@ function selectDisplay(layout: Layout, displays: DisplayInfo[]): DisplayInfo {
 				layout.display as DisplayAlias,
 			);
 			if (isAlias) {
-				selectedDisplay = getDisplayByAlias(layout.display as DisplayAlias, displays);
+				selectedDisplay = getDisplayByAlias(
+					layout.display as DisplayAlias,
+					displays,
+				);
 			} else {
 				selectedDisplay = getDisplayByName(layout.display, displays);
 			}

--- a/index.ts
+++ b/index.ts
@@ -134,7 +134,6 @@ const displays = getDisplays();
 if (!displays) {
   throw new Error(`No displays found. Please, debug with ${SPDisplayCommand}`);
 }
-console.log(displays);
 const selectedDisplay = selectDisplay(layout, displays);
 if (!selectedDisplay) {
   throw new Error(
@@ -204,7 +203,6 @@ function getDisplayByAlias(
   alias: DisplayAlias,
   displays: DisplayInfo[]
 ): DisplayInfo | undefined {
-  console.log("Getting display by alias:", alias, alias in DisplayAlias);
   switch (alias) {
     case DisplayAlias.Main:
       return displays.find((d) => d.isMain);

--- a/index.ts
+++ b/index.ts
@@ -274,9 +274,10 @@ function selectDisplay(layout: any, displays: DisplayInfo[]): DisplayInfo {
   }
 
   if (!selectedDisplay) {
-    throw new Error(
+    console.log(
       `Display not found: ${layout.display}. Please specify a valid display name, alias, or ID. Defaulting to the main display.`
     );
+    selectedDisplay = getDisplayByAlias(DisplayAlias.Main, displays);
   }
 
   console.log(

--- a/index.ts
+++ b/index.ts
@@ -6,96 +6,96 @@ import { execSync } from "node:child_process";
 
 // Types
 type WorkspaceLayout =
-  | "h_tiles"
-  | "v_tiles"
-  | "h_accordion"
-  | "v_accordion"
-  | "tiles"
-  | "accordion"
-  | "horizontal"
-  | "vertical"
-  | "tiling"
-  | "floating";
+	| "h_tiles"
+	| "v_tiles"
+	| "h_accordion"
+	| "v_accordion"
+	| "tiles"
+	| "accordion"
+	| "horizontal"
+	| "vertical"
+	| "tiling"
+	| "floating";
 type Orientation = "horizontal" | "vertical";
 type Size = `${number}/${number}`;
 interface LayoutWindow {
-  bundleId: string;
+	bundleId: string;
 }
 
 interface LayoutWindowWithSize extends LayoutWindow {
-  size: Size;
+	size: Size;
 }
 
 interface LayoutGroup {
-  orientation: Orientation;
-  windows: LayoutWindow[];
+	orientation: Orientation;
+	windows: LayoutWindow[];
 }
 
 interface LayoutGroupWithSize extends LayoutGroup {
-  size: Size;
+	size: Size;
 }
 
 type LayoutItem =
-  | LayoutWindow
-  | LayoutGroup
-  | LayoutWindowWithSize
-  | LayoutGroupWithSize;
+	| LayoutWindow
+	| LayoutGroup
+	| LayoutWindowWithSize
+	| LayoutGroupWithSize;
 
 type Layout = {
-  workspace: string;
-  layout: WorkspaceLayout;
-  orientation: Orientation;
-  windows: LayoutItem[];
-  display?: string | number;
+	workspace: string;
+	layout: WorkspaceLayout;
+	orientation: Orientation;
+	windows: LayoutItem[];
+	display?: string | number;
 };
 
 type LayoutConfig = {
-  stashWorkspace: string;
-  layouts: Record<string, Layout>;
+	stashWorkspace: string;
+	layouts: Record<string, Layout>;
 };
 
 type DisplayInfo = {
-  id?: number;
-  name: string;
-  width: number;
-  height: number;
-  isMain: boolean;
-  isInternal?: boolean;
+	id?: number;
+	name: string;
+	width: number;
+	height: number;
+	isMain: boolean;
+	isInternal?: boolean;
 };
 
 // macOS system_profiler SPDisplaysDataType reporter's values
 enum SPDisplaysValues {
-  Yes = "spdisplays_yes",
-  No = "spdisplays_no",
-  Supported = "spdisplays_supported",
-  Internal = "spdisplays_internal",
+	Yes = "spdisplays_yes",
+	No = "spdisplays_no",
+	Supported = "spdisplays_supported",
+	Internal = "spdisplays_internal",
 }
 
 const SPDisplayCommand = "system_profiler SPDisplaysDataType -json";
 
 enum DisplayAlias {
-  Main = "main",
-  Secondary = "secondary",
-  External = "external",
-  Internal = "internal",
+	Main = "main",
+	Secondary = "secondary",
+	External = "external",
+	Internal = "internal",
 }
 
 // Setup
 
 const args = parseArgs({
-  args: process.argv.slice(2),
-  options: {
-    layout: { type: "string", short: "l" },
-    configFile: {
-      type: "string",
-      short: "c",
-      default: "~/.config/aerospace/layouts.json",
-    },
-    listLayouts: { type: "boolean", short: "L" },
-    help: { type: "boolean", short: "h" },
-  },
-  strict: true,
-  allowPositionals: true,
+	args: process.argv.slice(2),
+	options: {
+		layout: { type: "string", short: "l" },
+		configFile: {
+			type: "string",
+			short: "c",
+			default: "~/.config/aerospace/layouts.json",
+		},
+		listLayouts: { type: "boolean", short: "L" },
+		help: { type: "boolean", short: "h" },
+	},
+	strict: true,
+	allowPositionals: true,
 });
 
 const layoutName = args.values.layout || args.positionals[0];
@@ -103,199 +103,199 @@ const configFilePath = await $`echo ${args.values.configFile}`.text();
 const layoutConfig: LayoutConfig = await Bun.file(configFilePath.trim()).json();
 
 if (args.values.listLayouts) {
-  console.log(Object.keys(layoutConfig.layouts).join("\n"));
-  process.exit(0);
+	console.log(Object.keys(layoutConfig.layouts).join("\n"));
+	process.exit(0);
 }
 
 function printHelp() {
-  console.log(
-    `\nAerospace Layout Manager\n\nUsage:\n  aerospace-layout-manager [options] <layout-name>\n\nOptions:\n  -l, --layout <layout-name>   Specify the layout name (can also be provided as the first positional argument)\n  -c, --configFile <path>      Path to the layout configuration file (default: ~/.config/aerospace/layouts.json)\n  -L, --listLayouts            List available layout names from the configuration file\n  -h, --help                   Show this help message and exit\n\nExamples:\n  # Apply the 'work' layout defined in the config\n  aerospace-layout-manager work\n\n  # Same as above using the explicit flag\n  aerospace-layout-manager --layout work\n\n  # List all available layouts\n  aerospace-layout-manager --listLayouts\n`
-  );
+	console.log(
+		`\nAerospace Layout Manager\n\nUsage:\n  aerospace-layout-manager [options] <layout-name>\n\nOptions:\n  -l, --layout <layout-name>   Specify the layout name (can also be provided as the first positional argument)\n  -c, --configFile <path>      Path to the layout configuration file (default: ~/.config/aerospace/layouts.json)\n  -L, --listLayouts            List available layout names from the configuration file\n  -h, --help                   Show this help message and exit\n\nExamples:\n  # Apply the 'work' layout defined in the config\n  aerospace-layout-manager work\n\n  # Same as above using the explicit flag\n  aerospace-layout-manager --layout work\n\n  # List all available layouts\n  aerospace-layout-manager --listLayouts\n`,
+	);
 }
 
 // Show help and exit if requested explicitly
 if (args.values.help || layoutName === "help") {
-  printHelp();
-  process.exit(0);
+	printHelp();
+	process.exit(0);
 }
 
 if (!layoutName) {
-  printHelp();
-  process.exit(0);
+	printHelp();
+	process.exit(0);
 }
 
 const layout = layoutConfig.layouts[layoutName];
 const stashWorkspace = layoutConfig.stashWorkspace ?? "S";
 
 if (!layout) {
-  throw new Error("Layout not found");
+	throw new Error("Layout not found");
 }
 
 const displays = getDisplays();
 if (!displays) {
-  throw new Error(`No displays found. Please, debug with ${SPDisplayCommand}`);
+	throw new Error(`No displays found. Please, debug with ${SPDisplayCommand}`);
 }
 const selectedDisplay = layout.display
-  ? selectDisplay(layout, displays)
-  : getDisplayByAlias(DisplayAlias.Main, displays);
+	? selectDisplay(layout, displays)
+	: getDisplayByAlias(DisplayAlias.Main, displays);
 if (!selectedDisplay) {
-  throw new Error(
-    `A display could not be selected for layout "${layoutName}". Please check your configuration.`
-  );
+	throw new Error(
+		`A display could not be selected for layout "${layoutName}". Please check your configuration.`,
+	);
 }
 
 // Helpers
 
 async function flattenWorkspace(workspace: string) {
-  await $`aerospace flatten-workspace-tree --workspace ${workspace}`.nothrow();
+	await $`aerospace flatten-workspace-tree --workspace ${workspace}`.nothrow();
 }
 
 async function switchToWorkspace(workspace: string) {
-  await $`aerospace workspace ${workspace}`.nothrow();
+	await $`aerospace workspace ${workspace}`.nothrow();
 }
 
 async function moveWindow(windowId: string, workspace: string) {
-  await $`aerospace move-node-to-workspace --window-id "${windowId}" "${workspace}" --focus-follows-window`;
+	await $`aerospace move-node-to-workspace --window-id "${windowId}" "${workspace}" --focus-follows-window`;
 }
 
 async function getWindowsInWorkspace(workspace: string): Promise<
-  {
-    "app-name": string;
-    "window-id": string;
-    "window-title": string;
-    "app-bundle-id": string;
-  }[]
+	{
+		"app-name": string;
+		"window-id": string;
+		"window-title": string;
+		"app-bundle-id": string;
+	}[]
 > {
-  return await $`aerospace list-windows --workspace ${workspace} --json --format "%{window-id} %{app-name} %{window-title} %{app-bundle-id}"`.json();
+	return await $`aerospace list-windows --workspace ${workspace} --json --format "%{window-id} %{app-name} %{window-title} %{app-bundle-id}"`.json();
 }
 
 async function joinItemWithPreviousWindow(windowId: string) {
-  await $`aerospace join-with --window-id ${windowId} left`.nothrow();
+	await $`aerospace join-with --window-id ${windowId} left`.nothrow();
 }
 
 async function focusWindow(windowId: string) {
-  await $`aerospace focus --window-id ${windowId}`.nothrow();
+	await $`aerospace focus --window-id ${windowId}`.nothrow();
 }
 
 function getDisplays(): DisplayInfo[] {
-  const json = execSync(SPDisplayCommand, { encoding: "utf8" });
-  const data = JSON.parse(json);
-  return data.SPDisplaysDataType.flatMap((gpu: any) =>
-    gpu.spdisplays_ndrvs.map((d: any) => ({
-      name: d._name,
-      id: parseInt(d._spdisplays_displayID) || undefined,
-      width: parseInt(
-        (d._spdisplays_resolution || d.spdisplays_resolution || "").split(
-          " x "
-        )[0],
-        10
-      ),
-      height: parseInt(
-        (d._spdisplays_resolution || d.spdisplays_resolution || "").split(
-          " x "
-        )[1],
-        10
-      ),
-      isMain: d.spdisplays_main === SPDisplaysValues.Yes,
-      isInternal: d.spdisplays_connection_type === SPDisplaysValues.Internal,
-    }))
-  );
+	const json = execSync(SPDisplayCommand, { encoding: "utf8" });
+	const data = JSON.parse(json);
+	return data.SPDisplaysDataType.flatMap((gpu: any) =>
+		gpu.spdisplays_ndrvs.map((d: any) => ({
+			name: d._name,
+			id: parseInt(d._spdisplays_displayID) || undefined,
+			width: parseInt(
+				(d._spdisplays_resolution || d.spdisplays_resolution || "").split(
+					" x ",
+				)[0],
+				10,
+			),
+			height: parseInt(
+				(d._spdisplays_resolution || d.spdisplays_resolution || "").split(
+					" x ",
+				)[1],
+				10,
+			),
+			isMain: d.spdisplays_main === SPDisplaysValues.Yes,
+			isInternal: d.spdisplays_connection_type === SPDisplaysValues.Internal,
+		})),
+	);
 }
 
 function getDisplayByAlias(
-  alias: DisplayAlias,
-  displays: DisplayInfo[]
+	alias: DisplayAlias,
+	displays: DisplayInfo[],
 ): DisplayInfo | undefined {
-  switch (alias) {
-    case DisplayAlias.Main:
-      return getMainDisplay(displays);
-    case DisplayAlias.Secondary:
-      if (displays.length < 2) {
-        console.log(
-          "Alias 'secondary' is used, but only one display found. Defaulting to the main display."
-        );
-        return getMainDisplay(displays);
-      }
-      if (displays.length > 2) {
-        throw new Error(
-          "Alias 'secondary' is used, but multiple secondary displays are found. Please specify an exact display name or use a different alias."
-        );
-      }
-      return displays.find((d) => !d.isMain);
-    case DisplayAlias.External:
-      const externalDisplays = displays.filter((d) => !d.isInternal);
-      if (externalDisplays.length === 0) {
-        console.log(
-          "Alias 'external' is used, but no external displays found. Defaulting to the main display."
-        );
-        return getMainDisplay(displays);
-      }
-      if (externalDisplays.length > 1) {
-        throw new Error(
-          "Multiple external displays found. Please specify an exact display name or use a different alias."
-        );
-      }
-      return externalDisplays[0];
-    case DisplayAlias.Internal:
-      return displays.find((d) => d.isInternal);
-  }
+	switch (alias) {
+		case DisplayAlias.Main:
+			return getMainDisplay(displays);
+		case DisplayAlias.Secondary:
+			if (displays.length < 2) {
+				console.log(
+					"Alias 'secondary' is used, but only one display found. Defaulting to the main display.",
+				);
+				return getMainDisplay(displays);
+			}
+			if (displays.length > 2) {
+				throw new Error(
+					"Alias 'secondary' is used, but multiple secondary displays are found. Please specify an exact display name or use a different alias.",
+				);
+			}
+			return displays.find((d) => !d.isMain);
+		case DisplayAlias.External:
+			const externalDisplays = displays.filter((d) => !d.isInternal);
+			if (externalDisplays.length === 0) {
+				console.log(
+					"Alias 'external' is used, but no external displays found. Defaulting to the main display.",
+				);
+				return getMainDisplay(displays);
+			}
+			if (externalDisplays.length > 1) {
+				throw new Error(
+					"Multiple external displays found. Please specify an exact display name or use a different alias.",
+				);
+			}
+			return externalDisplays[0];
+		case DisplayAlias.Internal:
+			return displays.find((d) => d.isInternal);
+	}
 }
 
 function getDisplayByName(
-  regExp: string,
-  displays: DisplayInfo[]
+	regExp: string,
+	displays: DisplayInfo[],
 ): DisplayInfo | undefined {
-  return displays.find((d) => new RegExp(regExp, "i").test(d.name));
+	return displays.find((d) => new RegExp(regExp, "i").test(d.name));
 }
 
 function getDisplayById(
-  id: number,
-  displays: DisplayInfo[]
+	id: number,
+	displays: DisplayInfo[],
 ): DisplayInfo | undefined {
-  return displays.find((d) => d.id === id);
+	return displays.find((d) => d.id === id);
 }
 
 function getMainDisplay(displays: DisplayInfo[]): DisplayInfo | undefined {
-  return displays.find((d) => d.isMain);
+	return displays.find((d) => d.isMain);
 }
 
 function selectDisplay(layout: any, displays: DisplayInfo[]): DisplayInfo {
-  let selectedDisplay: DisplayInfo | undefined;
-  if (layout.display) {
-    if (typeof layout.display === "string" && isNaN(Number(layout.display))) {
-      const isAlias = Object.values(DisplayAlias).includes(
-        layout.display as DisplayAlias
-      );
-      if (isAlias) {
-        selectedDisplay = getDisplayByAlias(layout.display, displays);
-      } else {
-        selectedDisplay = getDisplayByName(layout.display, displays);
-      }
-    } else if (
-      typeof layout.display === "number" ||
-      !isNaN(Number(layout.display))
-    ) {
-      const displayId = Number(layout.display);
-      selectedDisplay = getDisplayById(displayId, displays);
-    }
-  }
+	let selectedDisplay: DisplayInfo | undefined;
+	if (layout.display) {
+		if (typeof layout.display === "string" && isNaN(Number(layout.display))) {
+			const isAlias = Object.values(DisplayAlias).includes(
+				layout.display as DisplayAlias,
+			);
+			if (isAlias) {
+				selectedDisplay = getDisplayByAlias(layout.display, displays);
+			} else {
+				selectedDisplay = getDisplayByName(layout.display, displays);
+			}
+		} else if (
+			typeof layout.display === "number" ||
+			!isNaN(Number(layout.display))
+		) {
+			const displayId = Number(layout.display);
+			selectedDisplay = getDisplayById(displayId, displays);
+		}
+	}
 
-  if (!selectedDisplay) {
-    console.log(
-      `Display not found: ${layout.display}. Please specify a valid display name, alias, or ID. Defaulting to the main display.`
-    );
-    selectedDisplay = getDisplayByAlias(DisplayAlias.Main, displays);
-  }
+	if (!selectedDisplay) {
+		console.log(
+			`Display not found: ${layout.display}. Please specify a valid display name, alias, or ID. Defaulting to the main display.`,
+		);
+		selectedDisplay = getDisplayByAlias(DisplayAlias.Main, displays);
+	}
 
-  console.log(
-    `Using display: ${selectedDisplay.name} (${selectedDisplay.width}x${
-      selectedDisplay.height
-    }) (${selectedDisplay.isMain ? "main" : "secondary"}, ${
-      selectedDisplay.isInternal ? "internal" : "external"
-    })`
-  );
+	console.log(
+		`Using display: ${selectedDisplay.name} (${selectedDisplay.width}x${
+			selectedDisplay.height
+		}) (${selectedDisplay.isMain ? "main" : "secondary"}, ${
+			selectedDisplay.isInternal ? "internal" : "external"
+		})`,
+	);
 
-  return selectedDisplay;
+	return selectedDisplay;
 }
 
 /**
@@ -303,172 +303,172 @@ function selectDisplay(layout: any, displays: DisplayInfo[]): DisplayInfo {
  * Uses AppleScript because Aerospace does not expose this information.
  */
 async function getDisplayWidth(): Promise<number | null> {
-  return selectedDisplay?.width ?? null;
+	return selectedDisplay?.width ?? null;
 }
 
 async function getDisplayHeight(): Promise<number | null> {
-  return selectedDisplay?.height ?? null;
+	return selectedDisplay?.height ?? null;
 }
 
 // Functions
 
 // remove all windows from workspace
 async function clearWorkspace(workspace: string) {
-  const windows = await getWindowsInWorkspace(workspace);
+	const windows = await getWindowsInWorkspace(workspace);
 
-  for (const window of windows) {
-    if (window["window-id"]) {
-      await moveWindow(window["window-id"], stashWorkspace);
-    }
-  }
+	for (const window of windows) {
+		if (window["window-id"]) {
+			await moveWindow(window["window-id"], stashWorkspace);
+		}
+	}
 }
 
 async function getWindowId(bundleId: string) {
-  const bundleJson =
-    await $`aerospace list-windows --monitor all --app-bundle-id "${bundleId}" --json`.json();
-  const windowId = bundleJson?.length > 0 ? bundleJson[0]["window-id"] : null;
-  if (!windowId) {
-    console.log("No windowId found for", bundleId);
-  }
-  return windowId;
+	const bundleJson =
+		await $`aerospace list-windows --monitor all --app-bundle-id "${bundleId}" --json`.json();
+	const windowId = bundleJson?.length > 0 ? bundleJson[0]["window-id"] : null;
+	if (!windowId) {
+		console.log("No windowId found for", bundleId);
+	}
+	return windowId;
 }
 
 async function launchIfNotRunning(bundleId: string) {
-  const isRunning =
-    (await $`osascript -e "application id \"${bundleId}\" is running" | grep -q true`.text()) ===
-    "true";
-  if (!isRunning) {
-    await $`open -b "${bundleId}"`;
-  }
+	const isRunning =
+		(await $`osascript -e "application id \"${bundleId}\" is running" | grep -q true`.text()) ===
+		"true";
+	if (!isRunning) {
+		await $`open -b "${bundleId}"`;
+	}
 }
 
 async function ensureWindow(bundleId: string) {
-  await launchIfNotRunning(bundleId);
-  for await (const i of Array(30)) {
-    const windowId = await getWindowId(bundleId);
-    if (windowId) {
-      return windowId;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  return null;
+	await launchIfNotRunning(bundleId);
+	for await (const i of Array(30)) {
+		const windowId = await getWindowId(bundleId);
+		if (windowId) {
+			return windowId;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	return null;
 }
 
 async function setWorkspaceLayout(workspace: string, layout: WorkspaceLayout) {
-  const workspaceWindows = await getWindowsInWorkspace(workspace);
-  if (workspaceWindows.length > 0) {
-    const windowId = workspaceWindows?.[0]?.["window-id"];
-    await $`aerospace layout ${layout} --window-id ${windowId}`.nothrow();
-  }
+	const workspaceWindows = await getWindowsInWorkspace(workspace);
+	if (workspaceWindows.length > 0) {
+		const windowId = workspaceWindows?.[0]?.["window-id"];
+		await $`aerospace layout ${layout} --window-id ${windowId}`.nothrow();
+	}
 }
 
 async function traverseTreeMove(tree: LayoutItem[], depth = 0) {
-  for await (const [i, item] of tree.entries()) {
-    if ("bundleId" in item) {
-      const windowId = await ensureWindow(item.bundleId);
+	for await (const [i, item] of tree.entries()) {
+		if ("bundleId" in item) {
+			const windowId = await ensureWindow(item.bundleId);
 
-      if (windowId) {
-        await moveWindow(windowId, layout.workspace);
-      }
-    } else if ("windows" in item) {
-      await traverseTreeMove(item.windows, depth + 1);
-    }
-  }
+			if (windowId) {
+				await moveWindow(windowId, layout.workspace);
+			}
+		} else if ("windows" in item) {
+			await traverseTreeMove(item.windows, depth + 1);
+		}
+	}
 }
 
 async function traverseTreeReposition(tree: LayoutItem[], depth = 0) {
-  for await (const [i, item] of tree.entries()) {
-    if (depth === 0 && i === 0) {
-      // set workspace layout after moving first window
-      await flattenWorkspace(layout.workspace);
-      await setWorkspaceLayout(layout.workspace, layout.layout);
-    }
-    if ("bundleId" in item) {
-      if (depth > 0 && i > 0) {
-        // subsequent windows in a group should be joined with the previous window
-        const windowId = await getWindowId(item.bundleId);
-        if (windowId) {
-          await focusWindow(windowId);
-          await joinItemWithPreviousWindow(windowId);
-        }
-      }
-    } else if ("windows" in item) {
-      console.log("section:", item.orientation, "depth:", depth);
-      await traverseTreeReposition(item.windows, depth + 1);
-    }
-  }
+	for await (const [i, item] of tree.entries()) {
+		if (depth === 0 && i === 0) {
+			// set workspace layout after moving first window
+			await flattenWorkspace(layout.workspace);
+			await setWorkspaceLayout(layout.workspace, layout.layout);
+		}
+		if ("bundleId" in item) {
+			if (depth > 0 && i > 0) {
+				// subsequent windows in a group should be joined with the previous window
+				const windowId = await getWindowId(item.bundleId);
+				if (windowId) {
+					await focusWindow(windowId);
+					await joinItemWithPreviousWindow(windowId);
+				}
+			}
+		} else if ("windows" in item) {
+			console.log("section:", item.orientation, "depth:", depth);
+			await traverseTreeReposition(item.windows, depth + 1);
+		}
+	}
 }
 
 async function resizeWindow(
-  windowId: string,
-  size: Size,
-  dimension: "width" | "height"
+	windowId: string,
+	size: Size,
+	dimension: "width" | "height",
 ) {
-  console.log("Resizing window", windowId, "to", size);
-  const screenDimension =
-    dimension === "width" ? await getDisplayWidth() : await getDisplayHeight();
-  const [numerator, denominator] = size.split("/").map(Number);
-  console.log("Screen dimension:", screenDimension);
-  console.log("Numerator:", numerator);
-  console.log("Denominator:", denominator);
-  if (!screenDimension || !numerator || !denominator) {
-    console.error("Unable to determine display width");
-    return;
-  }
-  const newWidth = Math.floor(screenDimension * (numerator / denominator));
-  console.log("New width:", newWidth);
-  console.log(
-    "Command:",
-    `aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`
-  );
-  await $`aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`.nothrow();
+	console.log("Resizing window", windowId, "to", size);
+	const screenDimension =
+		dimension === "width" ? await getDisplayWidth() : await getDisplayHeight();
+	const [numerator, denominator] = size.split("/").map(Number);
+	console.log("Screen dimension:", screenDimension);
+	console.log("Numerator:", numerator);
+	console.log("Denominator:", denominator);
+	if (!screenDimension || !numerator || !denominator) {
+		console.error("Unable to determine display width");
+		return;
+	}
+	const newWidth = Math.floor(screenDimension * (numerator / denominator));
+	console.log("New width:", newWidth);
+	console.log(
+		"Command:",
+		`aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`,
+	);
+	await $`aerospace resize --window-id ${windowId} ${dimension} ${newWidth}`.nothrow();
 }
 
 function getDimension(item: LayoutItem) {
-  console.log("Item:", item);
-  if ("orientation" in item) {
-    return item.orientation === "horizontal" ? "width" : "height";
-  }
-  return layout.orientation === "horizontal" ? "width" : "height";
+	console.log("Item:", item);
+	if ("orientation" in item) {
+		return item.orientation === "horizontal" ? "width" : "height";
+	}
+	return layout.orientation === "horizontal" ? "width" : "height";
 }
 
 async function traverseTreeResize(
-  tree: LayoutItem[],
-  depth = 0,
-  parent: LayoutItem | null = null
+	tree: LayoutItem[],
+	depth = 0,
+	parent: LayoutItem | null = null,
 ) {
-  for await (const [i, item] of tree.entries()) {
-    if ("size" in item && "bundleId" in item) {
-      const windowId = await getWindowId(item.bundleId);
+	for await (const [i, item] of tree.entries()) {
+		if ("size" in item && "bundleId" in item) {
+			const windowId = await getWindowId(item.bundleId);
 
-      const dimension = getDimension(parent ?? item);
-      await resizeWindow(windowId, item.size, dimension);
-    } else if ("windows" in item) {
-      const firstChildWindow = item.windows[0];
-      console.log("Parent:", parent, "Item:", item);
-      console.log("First child window:", firstChildWindow);
-      if (
-        "size" in item &&
-        firstChildWindow &&
-        "bundleId" in firstChildWindow
-      ) {
-        console.log(
-          "Resizing first child window:",
-          firstChildWindow.bundleId,
-          "to",
-          item.size
-        );
-        const windowId = await getWindowId(firstChildWindow.bundleId);
-        const dimension = parent
-          ? getDimension(parent)
-          : layout.orientation === "horizontal"
-          ? "width"
-          : "height";
-        await resizeWindow(windowId, item.size, dimension);
-      }
-      await traverseTreeResize(item.windows, depth + 1, item);
-    }
-  }
+			const dimension = getDimension(parent ?? item);
+			await resizeWindow(windowId, item.size, dimension);
+		} else if ("windows" in item) {
+			const firstChildWindow = item.windows[0];
+			console.log("Parent:", parent, "Item:", item);
+			console.log("First child window:", firstChildWindow);
+			if (
+				"size" in item &&
+				firstChildWindow &&
+				"bundleId" in firstChildWindow
+			) {
+				console.log(
+					"Resizing first child window:",
+					firstChildWindow.bundleId,
+					"to",
+					item.size,
+				);
+				const windowId = await getWindowId(firstChildWindow.bundleId);
+				const dimension = parent
+					? getDimension(parent)
+					: layout.orientation === "horizontal"
+						? "width"
+						: "height";
+				await resizeWindow(windowId, item.size, dimension);
+			}
+			await traverseTreeResize(item.windows, depth + 1, item);
+		}
+	}
 }
 
 // Main

--- a/layoutConfig.schema.json
+++ b/layoutConfig.schema.json
@@ -1,119 +1,119 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://example.com/layoutConfig.schema.json",
-  "title": "LayoutConfig",
-  "type": "object",
-  "required": ["stashWorkspace", "layouts"],
-  "additionalProperties": false,
-  "properties": {
-    "stashWorkspace": {
-      "type": "string",
-      "description": "Workspace name used to stash windows while rearranging."
-    },
-    "layouts": {
-      "type": "object",
-      "description": "Mapping of layout names to their definitions.",
-      "additionalProperties": { "$ref": "#/definitions/Layout" }
-    }
-  },
-  "definitions": {
-    "WorkspaceLayout": {
-      "type": "string",
-      "enum": [
-        "h_tiles",
-        "v_tiles",
-        "h_accordion",
-        "v_accordion",
-        "tiles",
-        "accordion",
-        "horizontal",
-        "vertical",
-        "tiling",
-        "floating"
-      ]
-    },
-    "Orientation": {
-      "type": "string",
-      "enum": ["horizontal", "vertical"]
-    },
-    "Size": {
-      "type": "string",
-      "pattern": "^[0-9]+\\/[0-9]+$",
-      "description": "Fractional size expressed as 'numerator/denominator', e.g. '1/2'."
-    },
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/layoutConfig.schema.json",
+	"title": "LayoutConfig",
+	"type": "object",
+	"required": ["stashWorkspace", "layouts"],
+	"additionalProperties": false,
+	"properties": {
+		"stashWorkspace": {
+			"type": "string",
+			"description": "Workspace name used to stash windows while rearranging."
+		},
+		"layouts": {
+			"type": "object",
+			"description": "Mapping of layout names to their definitions.",
+			"additionalProperties": { "$ref": "#/definitions/Layout" }
+		}
+	},
+	"definitions": {
+		"WorkspaceLayout": {
+			"type": "string",
+			"enum": [
+				"h_tiles",
+				"v_tiles",
+				"h_accordion",
+				"v_accordion",
+				"tiles",
+				"accordion",
+				"horizontal",
+				"vertical",
+				"tiling",
+				"floating"
+			]
+		},
+		"Orientation": {
+			"type": "string",
+			"enum": ["horizontal", "vertical"]
+		},
+		"Size": {
+			"type": "string",
+			"pattern": "^[0-9]+\\/[0-9]+$",
+			"description": "Fractional size expressed as 'numerator/denominator', e.g. '1/2'."
+		},
 
-    "LayoutWindow": {
-      "type": "object",
-      "required": ["bundleId"],
-      "additionalProperties": false,
-      "properties": {
-        "bundleId": { "type": "string" }
-      }
-    },
+		"LayoutWindow": {
+			"type": "object",
+			"required": ["bundleId"],
+			"additionalProperties": false,
+			"properties": {
+				"bundleId": { "type": "string" }
+			}
+		},
 
-    "LayoutWindowWithSize": {
-      "allOf": [
-        { "$ref": "#/definitions/LayoutWindow" },
-        {
-          "type": "object",
-          "required": ["size"],
-          "additionalProperties": false,
-          "properties": {
-            "size": { "$ref": "#/definitions/Size" }
-          }
-        }
-      ]
-    },
+		"LayoutWindowWithSize": {
+			"allOf": [
+				{ "$ref": "#/definitions/LayoutWindow" },
+				{
+					"type": "object",
+					"required": ["size"],
+					"additionalProperties": false,
+					"properties": {
+						"size": { "$ref": "#/definitions/Size" }
+					}
+				}
+			]
+		},
 
-    "LayoutGroup": {
-      "type": "object",
-      "required": ["orientation", "windows"],
-      "additionalProperties": false,
-      "properties": {
-        "orientation": { "$ref": "#/definitions/Orientation" },
-        "windows": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/LayoutWindow" }
-        }
-      }
-    },
+		"LayoutGroup": {
+			"type": "object",
+			"required": ["orientation", "windows"],
+			"additionalProperties": false,
+			"properties": {
+				"orientation": { "$ref": "#/definitions/Orientation" },
+				"windows": {
+					"type": "array",
+					"items": { "$ref": "#/definitions/LayoutWindow" }
+				}
+			}
+		},
 
-    "LayoutGroupWithSize": {
-      "allOf": [
-        { "$ref": "#/definitions/LayoutGroup" },
-        {
-          "type": "object",
-          "required": ["size"],
-          "additionalProperties": false,
-          "properties": {
-            "size": { "$ref": "#/definitions/Size" }
-          }
-        }
-      ]
-    },
+		"LayoutGroupWithSize": {
+			"allOf": [
+				{ "$ref": "#/definitions/LayoutGroup" },
+				{
+					"type": "object",
+					"required": ["size"],
+					"additionalProperties": false,
+					"properties": {
+						"size": { "$ref": "#/definitions/Size" }
+					}
+				}
+			]
+		},
 
-    "LayoutItem": {
-      "oneOf": [
-        { "$ref": "#/definitions/LayoutWindow" },
-        { "$ref": "#/definitions/LayoutGroup" },
-        { "$ref": "#/definitions/LayoutWindowWithSize" },
-        { "$ref": "#/definitions/LayoutGroupWithSize" }
-      ]
-    },
+		"LayoutItem": {
+			"oneOf": [
+				{ "$ref": "#/definitions/LayoutWindow" },
+				{ "$ref": "#/definitions/LayoutGroup" },
+				{ "$ref": "#/definitions/LayoutWindowWithSize" },
+				{ "$ref": "#/definitions/LayoutGroupWithSize" }
+			]
+		},
 
-    "Layout": {
-      "type": "object",
-      "required": ["workspace", "layout", "orientation", "windows"],
-      "additionalProperties": false,
-      "properties": {
-        "workspace": { "type": "string" },
-        "layout": { "$ref": "#/definitions/WorkspaceLayout" },
-        "orientation": { "$ref": "#/definitions/Orientation" },
-        "windows": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/LayoutItem" }
-        }
-      }
-    }
-  }
-} 
+		"Layout": {
+			"type": "object",
+			"required": ["workspace", "layout", "orientation", "windows"],
+			"additionalProperties": false,
+			"properties": {
+				"workspace": { "type": "string" },
+				"layout": { "$ref": "#/definitions/WorkspaceLayout" },
+				"orientation": { "$ref": "#/definitions/Orientation" },
+				"windows": {
+					"type": "array",
+					"items": { "$ref": "#/definitions/LayoutItem" }
+				}
+			}
+		}
+	}
+}

--- a/layouts.json
+++ b/layouts.json
@@ -1,76 +1,75 @@
 {
-    "$schema": "https://raw.githubusercontent.com/CarterMcAlister/aerospace-layout-manager/main/layoutConfig.schema.json",
-    "stashWorkspace": "S",
-    "layouts": {
-        "dev": {
-            "workspace": "1",
-            "layout": "h_tiles",
-            "orientation": "horizontal",
-            "windows": [
-                {
-                    "bundleId": "com.apple.Xcode"
-                },
-                {
-                    "orientation": "vertical",
-                    "windows": [
-                        {
-                            "bundleId": "us.zoom.xos"
-                        },
-                        {
-                            "bundleId": "com.apple.Terminal"
-                        }
-                    ]
-                }
-            ]
-        },
-        "web": {
-            "workspace": "2",
-            "layout": "h_tiles",
-            "orientation": "horizontal",
-            "windows": [
-                {
-                    "bundleId": "md.obsidian",
-                    "size": "1/4"
-                },
-                {
-                    "bundleId": "company.thebrowser.Browser",
-                    "size": "1/2"
-                },
-                {
-                    "bundleId": "com.cron.electron",
-                    "size": "1/4"
-                }
-                
-            ]
-        },
-        "utils": {
-            "workspace": "3",
-            "layout": "h_tiles",
-            "orientation": "horizontal",
-            "windows": [
-                {
-                    "orientation": "vertical",
-                    "windows": [
-                        {
-                            "bundleId": "md.obsidian"
-                        },
-                        {
-                            "bundleId": "com.cron.electron"
-                        }
-                    ]
-                },
-                {
-                    "orientation": "vertical",
-                    "windows": [
-                        {
-                            "bundleId": "com.github.GitHubClient"
-                        },
-                        {
-                            "bundleId": "dev.warp.Warp-Stable"
-                        }
-                    ]
-                }
-            ]
-        }
-    }
+	"$schema": "https://raw.githubusercontent.com/CarterMcAlister/aerospace-layout-manager/main/layoutConfig.schema.json",
+	"stashWorkspace": "S",
+	"layouts": {
+		"dev": {
+			"workspace": "1",
+			"layout": "h_tiles",
+			"orientation": "horizontal",
+			"windows": [
+				{
+					"bundleId": "com.apple.Xcode"
+				},
+				{
+					"orientation": "vertical",
+					"windows": [
+						{
+							"bundleId": "us.zoom.xos"
+						},
+						{
+							"bundleId": "com.apple.Terminal"
+						}
+					]
+				}
+			]
+		},
+		"web": {
+			"workspace": "2",
+			"layout": "h_tiles",
+			"orientation": "horizontal",
+			"windows": [
+				{
+					"bundleId": "md.obsidian",
+					"size": "1/4"
+				},
+				{
+					"bundleId": "company.thebrowser.Browser",
+					"size": "1/2"
+				},
+				{
+					"bundleId": "com.cron.electron",
+					"size": "1/4"
+				}
+			]
+		},
+		"utils": {
+			"workspace": "3",
+			"layout": "h_tiles",
+			"orientation": "horizontal",
+			"windows": [
+				{
+					"orientation": "vertical",
+					"windows": [
+						{
+							"bundleId": "md.obsidian"
+						},
+						{
+							"bundleId": "com.cron.electron"
+						}
+					]
+				},
+				{
+					"orientation": "vertical",
+					"windows": [
+						{
+							"bundleId": "com.github.GitHubClient"
+						},
+						{
+							"bundleId": "dev.warp.Warp-Stable"
+						}
+					]
+				}
+			]
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aerospace-layout-manager",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"module": "index.ts",
 	"type": "module",
 	"private": true,


### PR DESCRIPTION
First and foremost, thanks @CarterMcAlister for the awesome work with the tool - it's super helpful and really pushes [AeroSpace](https://github.com/nikitabobko/AeroSpace) to the next level by actually enabling [mise in place](https://dictionary.cambridge.org/dictionary/english/mise-en-place) 👨‍🍳

However, in my multi-display setup, I found the calculation of the target sizes according to the destination display doesn't work correctly, failing to identify the display altogether.

I have gone ahead and re-implemented the display management logic, allowing for defining target displays for layouts:
* Added a new `display` field to layout configurations, allowing users to specify the target display
* Three modes to specify target displays: aliases (`main`, `secondary`, `external`, `internal`), display name (supports regular expressions), or display `id`.
* Automatic display detection and resolution using macOS's `system_profiler SPDisplaysDataType` reporter. This allows detecting display properties like resolution, main/internal status, and aliases.
* Fully backwards compatible with no breaking changes, verbose logging and sane defaults.