### PR TITLE
fix: resolve ShellError when checking if app is running

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -373,9 +373,8 @@ async function getWindowId(bundleId: string) {
 }
 
 async function launchIfNotRunning(bundleId: string) {
-	const isRunning =
-		(await $`osascript -e "application id \"${bundleId}\" is running" | grep -q true`.text()) ===
-		"true";
+	const result = await $`osascript -e "application id \"${bundleId}\" is running"`.text();
+	const isRunning = result.trim() === "true";
 	if (!isRunning) {
 		await $`open -b "${bundleId}"`;
 	}


### PR DESCRIPTION
The `launchIfNotRunning` function was using `grep -q true` to check the osascript output, which caused Bun's shell to throw a ShellError when the app was not running.

Problem:
- `grep -q` returns exit code 1 when pattern is not found
- Bun's shell (`$`) throws an error on non-zero exit codes
- This caused the entire layout manager to crash instead of launching the app

Solution:
- Remove the pipe to `grep -q true`
- Check the osascript output directly with `.trim() === "true"`

This is a simpler and more reliable approach that works correctly regardless of whether the app is running or not.